### PR TITLE
fix: fixes #81 - update DNN.init() to correctly accept 4 arguments

### DIFF
--- a/src/dynadojo/baselines/dnn.py
+++ b/src/dynadojo/baselines/dnn.py
@@ -170,8 +170,9 @@ class DNN(TorchBaseClass):
     def __init__(self, 
             embed_dim,
             timesteps,
+            max_control_cost,
             **kwargs):
-        super().__init__(embed_dim, timesteps, **kwargs)
+        super().__init__(embed_dim, timesteps, max_control_cost, **kwargs)
         self.model = torch.nn.Sequential(
             torch.nn.Linear(self.embed_dim, embed_dim*10),
             torch.nn.ReLU(),


### PR DESCRIPTION
Resolves #81 
debugged DNN.init() to accept 4 arguments when it was previously missing a 'max_control_cost' argument