### PR TITLE
bug/tests: fix unittests, remove dnn printing, no more github testing for macOS

### DIFF
--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10'] #3.11
-        os: [ubuntu-latest, macOS-latest] #,windows-latest]
+        os: [ubuntu-latest] #, macOS-latest] #,windows-latest]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/src/dynadojo/baselines/dnn.py
+++ b/src/dynadojo/baselines/dnn.py
@@ -10,7 +10,7 @@ from torch.utils.data import DataLoader, TensorDataset, random_split
 import time
 
 from ..abstractions import AbstractAlgorithm
-
+import logging
 
 
 class TorchBaseClass(AbstractAlgorithm, torch.nn.Module):
@@ -33,7 +33,8 @@ class TorchBaseClass(AbstractAlgorithm, torch.nn.Module):
             torch.manual_seed(seed)
 
         self.device = device or "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
-        print(f"Using device: {self.device}")
+        logging.info(f"Using device: {self.device}")
+        # print(f"Using device: {self.device}")
         # self.model = self.create_model()
         self.criterion = torch.nn.MSELoss()
     
@@ -90,7 +91,7 @@ class TorchBaseClass(AbstractAlgorithm, torch.nn.Module):
         losses = []
         self.train() 
         training_start_time = time.time()
-        print(f'Dataloader length: {len(dataloader)}')
+        # print(f'Dataloader length: {len(dataloader)}')
         for epoch in range(epochs):
             self.train()
             epoch_loss = 0

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -157,7 +157,7 @@ class TestReproducibilityModel(unittest.TestCase):
                                  algo_kwargs=None)
         cols = ['trial', 'latent_dim', 'embed_dim', 'timesteps', 'n', 'error', 'ood_error', 'total_cost',
                 'system_seed', 'algo_seed']
-        df1 = df1[cols]
+        df1 = df1[cols].loc[df2['trial'] == 1]
         df2 = df2[cols].loc[df2['trial'] == 1]
         self.assertEqual(df1, df2)
 


### PR DESCRIPTION
Removes unnecessary printing in DNN
Fixes dimension mismatch in unittest
Comment out CD tests for macOS because of error:
```
RuntimeError: MPS backend out of memory (MPS allocated: 0 bytes, other allocations: 0 bytes, max allowed: 7.93 GB). Tried to allocate 768 bytes on private pool. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 to disable upper limit for memory allocations (may cause system failure).
```